### PR TITLE
Add Heroku Procfile and local setup docs

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: npm start

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # Jeffrey
-# Jeffrey
+
+A Discord bot that uses OpenAI and Postgres.
+
+## Local setup
+
+1. Run `npm install`.
+2. Create a `.env` file in the project root with your tokens:
+   - `ACCESS_TOKEN_DISCORD`
+   - `CLIENT_ID`
+   - `DATABASE_URL`
+   - `GUILD_ID` (optional)
+   - `OPENAI_API_KEY` or `ACCESS_TOKEN_OPENAI`
+3. Start the bot with `npm start`.
+
+## Heroku deployment
+
+Heroku reads the `Procfile` and runs `npm start` continuously. Set the same environment variables in the Heroku dashboard and the bot will stay online as long as the dyno is running.


### PR DESCRIPTION
## Summary
- add a `Procfile` so Heroku runs `npm start`
- document local environment setup and Heroku deployment instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e0605376883209f65e015a60e7d1b