### PR TITLE
Switch to OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ A Discord bot that uses OpenAI and Postgres.
    - `CLIENT_ID`
    - `DATABASE_URL`
    - `GUILD_ID` (optional)
-   - `OPENAI_API_KEY` or `ACCESS_TOKEN_OPENAI`
+   - `OPENAI_API_KEY`
 3. Start the bot with `npm start`.
+
+The bot reads the `OPENAI_API_KEY` environment variable for OpenAI access.
 
 ## Heroku deployment
 

--- a/features/openaiService.js
+++ b/features/openaiService.js
@@ -1,8 +1,6 @@
 // features/openaiService.js
 const OpenAI = require("openai");
-const { ACCESS_TOKEN_OPENAI } = process.env;
-
-const openai = new OpenAI({ apiKey: ACCESS_TOKEN_OPENAI });
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 let log = [{ role: "system", content: "You are a general friendly assistant who is knowledgeable about code." }];
 


### PR DESCRIPTION
## Summary
- normalize on `OPENAI_API_KEY`
- update OpenAI service to read this variable
- document the env variable in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e1081cfdc8320a50275c66269ab3e