### PR TITLE
Limit OpenAI request log

### DIFF
--- a/features/openaiService.js
+++ b/features/openaiService.js
@@ -8,6 +8,8 @@ let log = [{ role: "system", content: "You are a general friendly assistant who 
 
 module.exports.getOpenAIResponse = async (userMessage, maxTokens = 1000) => {
   log.push({ role: "user", content: userMessage });
+  // Keep only the most recent ~20 messages to avoid unbounded growth
+  if (log.length > 20) log.shift();
   const completion = await openai.chat.completions.create({
     messages: log,
     model: "gpt-4o",
@@ -15,5 +17,6 @@ module.exports.getOpenAIResponse = async (userMessage, maxTokens = 1000) => {
   });
   const response = completion.choices[0].message.content;
   log.push({ role: "system", content: response });
+  if (log.length > 20) log.shift();
   return response;
 };


### PR DESCRIPTION
## Summary
- cap `log` array in `features/openaiService.js` to the most recent ~20 messages
- document the retention policy

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e1085aa5c83209ddff2d48a2e9dbb