### PR TITLE
Fix duplicate Student message heading

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -117,7 +117,6 @@ const STUDENT_MESSAGE =
 "**2️⃣ /askquestion** – Ask staff or mentors a question.\n" +
 "**3️⃣ /resources** – Access helpful resources.\n\n" +
 "## Conversation‑history queries _(ask these in a DM to Jeffrey)_\n" +
-"## Conversation-history queries _(ask these in a DM to Jeffrey)_\n" +
 "• **Who asked about \\\"something\\\" in the chat?**\n" +
 "• **When was \\\"something\\\" last mentioned?**\n" +
 "• **Who said \\\"something\\\" in the chat?**\n" +


### PR DESCRIPTION
## Summary
- remove repeated conversation-history heading in `bot.js`

## Testing
- `node --check bot.js`

------
https://chatgpt.com/codex/tasks/task_e_687e10874f8483209e269e2b28a29f42