### PR TITLE
Handle poll modal errors

### DIFF
--- a/features/pollManager.js
+++ b/features/pollManager.js
@@ -1,0 +1,40 @@
+const { ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } = require('discord.js');
+
+/**
+ * Display a modal asking the user for poll details.
+ * The modal uses the custom ID `create-poll`.
+ */
+async function handleCreatePollButton(interaction) {
+  const modal = new ModalBuilder()
+    .setCustomId('create-poll')
+    .setTitle('Create Poll');
+
+  const question = new TextInputBuilder()
+    .setCustomId('poll-question')
+    .setLabel('Poll question')
+    .setStyle(TextInputStyle.Short)
+    .setRequired(true);
+
+  const options = new TextInputBuilder()
+    .setCustomId('poll-options')
+    .setLabel('Options (comma separated)')
+    .setStyle(TextInputStyle.Paragraph)
+    .setRequired(true);
+
+  modal.addComponents(
+    new ActionRowBuilder().addComponents(question),
+    new ActionRowBuilder().addComponents(options)
+  );
+
+  try {
+    await interaction.showModal(modal);
+  } catch (err) {
+    // 40060 = Interaction has already been acknowledged
+    if (err.code !== 40060) {
+      console.error('Failed to show poll modal:', err);
+    }
+    // Ignore 40060 so the client does not emit an unhandled error
+  }
+}
+
+module.exports = { handleCreatePollButton };


### PR DESCRIPTION
## Summary
- add a poll manager with create-poll modal
- catch Discord error `40060` when showing the modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6884bae07ff4832090eaf9583a3fabf0