### PR TITLE
Add daily study tip feature

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -38,6 +38,7 @@ const handleGeneralQuestion = require('./features/generalQuestion');
 const queueManager = require('./queueManager');
 const { setupStudentQueueChannel, setupStaffQueueChannel } = queueManager;
 const { activeQueue } = queueManager;   // use the shared map from queueManager
+const studyTips = require('./features/studyTips');
 
 const clientDB = require('./database');
 
@@ -343,6 +344,8 @@ client.once('ready', async () => {
         await backfillGuildHistory(guild);
         console.log(`Backfill complete for ${guild.name}.`);
     }
+
+    studyTips.setupStudyTips(client);
 });
 
 /**

--- a/features/studyTips.js
+++ b/features/studyTips.js
@@ -1,0 +1,142 @@
+const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const fs   = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, '..', 'studyTipConfig.json');
+const DEFAULT_CONFIG = { enabled: true, hour: 9, minute: 0, days: 1, channelId: null };
+let config = { ...DEFAULT_CONFIG };
+let timeout = null;
+
+function loadConfig() {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+    Object.assign(config, JSON.parse(raw));
+  } catch (_) {
+    saveConfig();
+  }
+}
+
+function saveConfig() {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+}
+
+function nextTriggerDate() {
+  const now = new Date();
+  let next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), config.hour, config.minute, 0));
+  while (next <= now) {
+    next.setUTCDate(next.getUTCDate() + config.days);
+  }
+  return next;
+}
+
+const tips = [
+  'Review new material within 24 hours to boost retention.',
+  'Explain concepts aloud as if teaching someone else.',
+  'Take short breaks every hour to stay focused.',
+  'Practice recalling information without looking at your notes.',
+  'Organise your study space to minimise distractions.'
+];
+
+async function sendTip(client) {
+  try {
+    let channel;
+    if (config.channelId) {
+      channel = await client.channels.fetch(config.channelId).catch(() => null);
+    } else {
+      channel = client.channels.cache.find(c => c.name === 'general' && c.isTextBased());
+    }
+    if (!channel) {
+      console.warn('Study tip channel not found.');
+      return;
+    }
+    const tip = tips[Math.floor(Math.random() * tips.length)];
+    await channel.send(`\uD83D\uDCDA **Study Tip:** ${tip}`);
+  } catch (err) {
+    console.error('Failed to send study tip:', err);
+  }
+}
+
+function scheduleNext(client) {
+  if (timeout) clearTimeout(timeout);
+  if (!config.enabled) return;
+  const next = nextTriggerDate();
+  const delay = next.getTime() - Date.now();
+  timeout = setTimeout(async () => {
+    await sendTip(client);
+    scheduleNext(client);
+  }, delay);
+}
+
+function setupStudyTips(client) {
+  loadConfig();
+  scheduleNext(client);
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('studytip')
+    .setDescription('Manage daily study tips')
+    .addSubcommand(sc => sc.setName('enable').setDescription('Enable daily tips'))
+    .addSubcommand(sc => sc.setName('disable').setDescription('Disable daily tips'))
+    .addSubcommand(sc => sc.setName('settime')
+      .setDescription('Set time of day in UTC')
+      .addIntegerOption(o => o.setName('hour').setDescription('0-23').setRequired(true))
+      .addIntegerOption(o => o.setName('minute').setDescription('0-59').setRequired(true)))
+    .addSubcommand(sc => sc.setName('frequency')
+      .setDescription('Set days between tips')
+      .addIntegerOption(o => o.setName('days').setDescription('Number of days').setRequired(true)))
+    .addSubcommand(sc => sc.setName('channel')
+      .setDescription('Set target channel')
+      .addChannelOption(o =>
+        o.setName('channel').setDescription('Text channel').setRequired(true).addChannelTypes(ChannelType.GuildText))),
+  async execute(interaction) {
+    const staffRole = interaction.guild.roles.cache.find(r => r.name === 'Staff');
+    if (!staffRole || !interaction.member.roles.cache.has(staffRole.id)) {
+      return interaction.reply({ content: '⛔ Staff only.', ephemeral: true });
+    }
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'enable') {
+      config.enabled = true;
+      saveConfig();
+      scheduleNext(interaction.client);
+      return interaction.reply({ content: 'Study tips enabled.', ephemeral: true });
+    }
+    if (sub === 'disable') {
+      config.enabled = false;
+      saveConfig();
+      if (timeout) clearTimeout(timeout);
+      return interaction.reply({ content: 'Study tips disabled.', ephemeral: true });
+    }
+    if (sub === 'settime') {
+      const h = interaction.options.getInteger('hour');
+      const m = interaction.options.getInteger('minute');
+      if (h < 0 || h > 23 || m < 0 || m > 59) {
+        return interaction.reply({ content: '⛔ Invalid time.', ephemeral: true });
+      }
+      config.hour = h;
+      config.minute = m;
+      saveConfig();
+      scheduleNext(interaction.client);
+      return interaction.reply({ content: `Time set to ${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')} UTC`, ephemeral: true });
+    }
+    if (sub === 'frequency') {
+      const d = interaction.options.getInteger('days');
+      if (d < 1) return interaction.reply({ content: '⛔ Days must be at least 1.', ephemeral: true });
+      config.days = d;
+      saveConfig();
+      scheduleNext(interaction.client);
+      return interaction.reply({ content: `Frequency set to every ${d} day(s).`, ephemeral: true });
+    }
+    if (sub === 'channel') {
+      const channel = interaction.options.getChannel('channel');
+      if (channel.type !== ChannelType.GuildText) {
+        return interaction.reply({ content: '⛔ Please choose a text channel.', ephemeral: true });
+      }
+      config.channelId = channel.id;
+      saveConfig();
+      scheduleNext(interaction.client);
+      return interaction.reply({ content: `Study tips will post in ${channel}.`, ephemeral: true });
+    }
+  },
+  setupStudyTips
+};

--- a/studyTipConfig.json
+++ b/studyTipConfig.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "hour": 9,
+  "minute": 0,
+  "days": 1,
+  "channelId": null
+}


### PR DESCRIPTION
## Summary
- introduce `studyTips` feature for daily scheduled messages
- add default configuration file
- register study tip scheduler in bot startup

## Testing
- `node --check features/studyTips.js`
- `node --check bot.js`


------
https://chatgpt.com/codex/tasks/task_e_6884d6c2cb38832084ff3d4c590527d4