### PR TITLE
Add DM-based study tips with configurable schedule

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -164,6 +164,7 @@ async function refreshChannels(guild) {
     // Re-ensure that the student and staff channels are set up with updated permissions and documentation
     await ensureStudentQueueChannel(guild);
     await ensureStaffQueueChannel(guild);
+    await studyTips.ensureSettingsChannel(guild);
     await setupDocumentationChannels(guild);
 }
 
@@ -356,6 +357,7 @@ client.on('guildCreate', async (guild) => {
     await ensureRolesForGuild(guild);
     await setupDocumentationChannels(guild);
     await ensureQueueChannel(guild);
+    await studyTips.ensureSettingsChannel(guild);
 });
 
 /**

--- a/features/studyTips.js
+++ b/features/studyTips.js
@@ -3,7 +3,15 @@ const fs   = require('fs');
 const path = require('path');
 
 const CONFIG_PATH = path.join(__dirname, '..', 'studyTipConfig.json');
-const DEFAULT_CONFIG = { enabled: true, hour: 9, minute: 0, days: 1, channelId: null };
+const DEFAULT_CONFIG = {
+  enabled: true,
+  hour: 9,
+  minute: 0,
+  days: 1,
+  count: 1,
+  dayOfWeek: null,
+  settingsChannelId: null,
+};
 let config = { ...DEFAULT_CONFIG };
 let timeout = null;
 
@@ -20,11 +28,65 @@ function saveConfig() {
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
 }
 
+async function ensureSettingsChannel(guild) {
+  try {
+    let ch = config.settingsChannelId
+      ? guild.channels.cache.get(config.settingsChannelId)
+      : guild.channels.cache.find(
+          c => c.name === 'study-tip-settings' && c.type === ChannelType.GuildText
+        );
+    const staffRole = guild.roles.cache.find(r => r.name === 'Staff');
+    if (!ch) {
+      ch = await guild.channels.create({
+        name: 'study-tip-settings',
+        type: ChannelType.GuildText,
+        permissionOverwrites: [
+          { id: guild.id, deny: ['ViewChannel'] },
+          { id: guild.client.user.id, allow: ['ViewChannel', 'SendMessages', 'ManageMessages', 'ManageChannels'] },
+          ...(staffRole ? [{ id: staffRole.id, allow: ['ViewChannel', 'SendMessages'] }] : [])
+        ]
+      });
+    } else {
+      if (staffRole && !ch.permissionOverwrites.cache.has(staffRole.id)) {
+        await ch.permissionOverwrites.edit(staffRole, { ViewChannel: true, SendMessages: true });
+      }
+      if (!ch.permissionOverwrites.cache.has(guild.client.user.id)) {
+        await ch.permissionOverwrites.edit(guild.client.user.id, {
+          ViewChannel: true,
+          SendMessages: true,
+          ManageMessages: true,
+          ManageChannels: true,
+        });
+      }
+    }
+    if (config.settingsChannelId !== ch.id) {
+      config.settingsChannelId = ch.id;
+      saveConfig();
+    }
+    return ch;
+  } catch (err) {
+    console.error(`Failed to ensure study tip settings channel for ${guild.name}:`, err);
+  }
+}
+
 function nextTriggerDate() {
   const now = new Date();
-  let next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), config.hour, config.minute, 0));
-  while (next <= now) {
-    next.setUTCDate(next.getUTCDate() + config.days);
+  let next = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    config.hour,
+    config.minute,
+    0
+  ));
+  if (typeof config.dayOfWeek === 'number') {
+    while (next.getUTCDay() !== config.dayOfWeek || next <= now) {
+      next.setUTCDate(next.getUTCDate() + 1);
+    }
+  } else {
+    while (next <= now) {
+      next.setUTCDate(next.getUTCDate() + config.days);
+    }
   }
   return next;
 }
@@ -39,18 +101,31 @@ const tips = [
 
 async function sendTip(client) {
   try {
-    let channel;
-    if (config.channelId) {
-      channel = await client.channels.fetch(config.channelId).catch(() => null);
-    } else {
-      channel = client.channels.cache.find(c => c.name === 'general' && c.isTextBased());
+    const tipCount = Math.max(1, config.count || 1);
+    const chosen = [];
+    for (let i = 0; i < tipCount; i++) {
+      chosen.push(tips[Math.floor(Math.random() * tips.length)]);
     }
-    if (!channel) {
-      console.warn('Study tip channel not found.');
-      return;
+    const msg = chosen.map((t, i) => `${i + 1}. ${t}`).join('\n');
+
+    for (const guild of client.guilds.cache.values()) {
+      const studentRole = guild.roles.cache.find(r => r.name === 'Students');
+      if (!studentRole) continue;
+      let members;
+      try {
+        members = await guild.members.fetch();
+      } catch (_) {
+        continue;
+      }
+      const students = members.filter(m => m.roles.cache.has(studentRole.id) && !m.user.bot);
+      for (const member of students.values()) {
+        try {
+          await member.send(`\uD83D\uDCDA **Study Tip${tipCount > 1 ? 's' : ''}:**\n${msg}`);
+        } catch (err) {
+          console.error('Failed to DM study tip to', member.user.tag, err);
+        }
+      }
     }
-    const tip = tips[Math.floor(Math.random() * tips.length)];
-    await channel.send(`\uD83D\uDCDA **Study Tip:** ${tip}`);
   } catch (err) {
     console.error('Failed to send study tip:', err);
   }
@@ -69,15 +144,18 @@ function scheduleNext(client) {
 
 function setupStudyTips(client) {
   loadConfig();
+  for (const [, guild] of client.guilds.cache) {
+    ensureSettingsChannel(guild);
+  }
   scheduleNext(client);
 }
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('studytip')
-    .setDescription('Manage daily study tips')
-    .addSubcommand(sc => sc.setName('enable').setDescription('Enable daily tips'))
-    .addSubcommand(sc => sc.setName('disable').setDescription('Disable daily tips'))
+    .setDescription('Manage scheduled study tips')
+    .addSubcommand(sc => sc.setName('enable').setDescription('Enable tips'))
+    .addSubcommand(sc => sc.setName('disable').setDescription('Disable tips'))
     .addSubcommand(sc => sc.setName('settime')
       .setDescription('Set time of day in UTC')
       .addIntegerOption(o => o.setName('hour').setDescription('0-23').setRequired(true))
@@ -85,14 +163,19 @@ module.exports = {
     .addSubcommand(sc => sc.setName('frequency')
       .setDescription('Set days between tips')
       .addIntegerOption(o => o.setName('days').setDescription('Number of days').setRequired(true)))
-    .addSubcommand(sc => sc.setName('channel')
-      .setDescription('Set target channel')
-      .addChannelOption(o =>
-        o.setName('channel').setDescription('Text channel').setRequired(true).addChannelTypes(ChannelType.GuildText))),
+    .addSubcommand(sc => sc.setName('count')
+      .setDescription('Number of tips per send')
+      .addIntegerOption(o => o.setName('count').setDescription('1 or more').setRequired(true)))
+    .addSubcommand(sc => sc.setName('day')
+      .setDescription('Day of week (0=Sun)')
+      .addIntegerOption(o => o.setName('day').setDescription('0-6').setRequired(true))),
   async execute(interaction) {
     const staffRole = interaction.guild.roles.cache.find(r => r.name === 'Staff');
     if (!staffRole || !interaction.member.roles.cache.has(staffRole.id)) {
       return interaction.reply({ content: '⛔ Staff only.', ephemeral: true });
+    }
+    if (config.settingsChannelId && interaction.channelId !== config.settingsChannelId) {
+      return interaction.reply({ content: '⛔ Use the study-tip-settings channel for this command.', ephemeral: true });
     }
     const sub = interaction.options.getSubcommand();
     if (sub === 'enable') {
@@ -127,16 +210,24 @@ module.exports = {
       scheduleNext(interaction.client);
       return interaction.reply({ content: `Frequency set to every ${d} day(s).`, ephemeral: true });
     }
-    if (sub === 'channel') {
-      const channel = interaction.options.getChannel('channel');
-      if (channel.type !== ChannelType.GuildText) {
-        return interaction.reply({ content: '⛔ Please choose a text channel.', ephemeral: true });
-      }
-      config.channelId = channel.id;
+    if (sub === 'count') {
+      const c = interaction.options.getInteger('count');
+      if (c < 1) return interaction.reply({ content: '⛔ Count must be at least 1.', ephemeral: true });
+      config.count = c;
       saveConfig();
       scheduleNext(interaction.client);
-      return interaction.reply({ content: `Study tips will post in ${channel}.`, ephemeral: true });
+      return interaction.reply({ content: `Each reminder will contain ${c} tip(s).`, ephemeral: true });
+    }
+    if (sub === 'day') {
+      const d = interaction.options.getInteger('day');
+      if (d < 0 || d > 6) return interaction.reply({ content: '⛔ Day must be between 0 and 6.', ephemeral: true });
+      config.dayOfWeek = d;
+      saveConfig();
+      scheduleNext(interaction.client);
+      const dayNames = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+      return interaction.reply({ content: `Study tips will send on ${dayNames[d]}.`, ephemeral: true });
     }
   },
-  setupStudyTips
+  setupStudyTips,
+  ensureSettingsChannel
 };

--- a/studyTipConfig.json
+++ b/studyTipConfig.json
@@ -3,5 +3,7 @@
   "hour": 9,
   "minute": 0,
   "days": 1,
-  "channelId": null
+  "count": 1,
+  "dayOfWeek": null,
+  "settingsChannelId": null
 }


### PR DESCRIPTION
## Summary
- deliver study tips via DM instead of in a public channel
- allow staff to change tip frequency, count and day of week
- restrict `/studytip` commands to a dedicated `study-tip-settings` channel
- ensure the settings channel exists for every guild

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688641a94b248320ab9272344277418d