### PR TITLE
Simplify study tip scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,5 @@ Heroku reads the `Procfile` and runs `npm start` continuously. Set the same envi
 
 ## Study tips
 
-A dedicated `#study-tip-settings` channel lets staff control how often tips are sent.
-The pinned panel provides dropdown menus for the hour, minute, frequency and tip count. Each menu's options include units (e.g. `09 h`, `30 min`) so it's clear what you're setting. New tips are generated with ChatGPT and are delivered to every student via DM.
-The pinned panel provides dropdown menus for the hour, minute, frequency and tip count. New tips are generated with ChatGPT and are delivered to every student via DM.
-The pinned panel provides dropdown menus for the hour, minute, frequency and tip count, plus a day-of-week selector. New tips are generated with ChatGPT and are delivered to every student via DM.
+A dedicated `#study-tip-settings` channel lets staff enable or disable weekly tips.
+When enabled, every student receives a new tip via DM each Sunday at **12:00 UK time**.

--- a/bot.js
+++ b/bot.js
@@ -844,12 +844,7 @@ client.on('interactionCreate', async (interaction) => {
         await handleEditQueueModal(interaction);
         return;
     }
-    if (interaction.isStringSelectMenu() && interaction.customId.startsWith('study-')) {
-        await studyTips.handleStudyTipSelect(interaction);
-        return;
-    }
-    
-    if (!interaction.isButton() && !interaction.isStringSelectMenu()) return;
+    if (!interaction.isButton()) return;
 
     // Let the generalQuestion collector handle these
     if (interaction.customId === 'yes_private_help' || interaction.customId === 'no_private_help') {
@@ -927,12 +922,6 @@ client.on('interactionCreate', async (interaction) => {
                 await studyTips.handleStudyTipButton(interaction);
                 break;
             
-            case 'study-hour-select':
-            case 'study-minute-select':
-            case 'study-freq-select':
-            case 'study-count-select':
-                await studyTips.handleStudyTipSelect(interaction);
-                break;
 
           /* ---------- Fallback ---------- */
           default:

--- a/features/studyTips.js
+++ b/features/studyTips.js
@@ -2,7 +2,6 @@ const {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
-  StringSelectMenuBuilder,
   EmbedBuilder,
   ChannelType,
 } = require('discord.js');
@@ -14,14 +13,10 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const CONFIG_PATH = path.join(__dirname, '..', 'studyTipConfig.json');
 const DEFAULT_CONFIG = {
   enabled: true,
-  hour: 9,
-  minute: 0,
-  days: 1,
-  count: 1,
-  dayOfWeek: null,
   settingsChannelId: null,
 };
 let config = { ...DEFAULT_CONFIG };
+const TIP_COUNT = 1;
 let timeout = null;
 
 function loadConfig() {
@@ -78,24 +73,32 @@ async function ensureSettingsChannel(guild) {
   }
 }
 
+function lastSundayOfMonth(year, month) {
+  const d = new Date(Date.UTC(year, month + 1, 0));
+  const day = d.getUTCDay();
+  d.setUTCDate(d.getUTCDate() - day);
+  d.setUTCHours(1, 0, 0, 0); // 1:00 UTC
+  return d;
+}
+
+function isUkDst(date) {
+  const year = date.getUTCFullYear();
+  const start = lastSundayOfMonth(year, 2); // March
+  const end = lastSundayOfMonth(year, 9);   // October
+  return date >= start && date < end;
+}
+
+function londonNoonUtc(year, month, day) {
+  const dt = new Date(Date.UTC(year, month, day, 12, 0, 0));
+  if (isUkDst(dt)) dt.setUTCMinutes(dt.getUTCMinutes() - 60);
+  return dt;
+}
+
 function nextTriggerDate() {
   const now = new Date();
-  let next = new Date(Date.UTC(
-    now.getUTCFullYear(),
-    now.getUTCMonth(),
-    now.getUTCDate(),
-    config.hour,
-    config.minute,
-    0
-  ));
-  if (typeof config.dayOfWeek === 'number') {
-    while (next.getUTCDay() !== config.dayOfWeek || next <= now) {
-      next.setUTCDate(next.getUTCDate() + 1);
-    }
-  } else {
-    while (next <= now) {
-      next.setUTCDate(next.getUTCDate() + config.days);
-    }
+  let next = londonNoonUtc(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  while (next <= now || next.getUTCDay() !== 0) {
+    next = londonNoonUtc(next.getUTCFullYear(), next.getUTCMonth(), next.getUTCDate() + 1);
   }
   return next;
 }
@@ -125,8 +128,7 @@ async function fetchTips(count) {
 
 async function sendTip(client) {
   try {
-    const numTips = Math.max(1, config.count || 1);
-    const tips = await fetchTips(numTips);
+    const tips = await fetchTips(TIP_COUNT);
     const msg = tips.map((t, i) => `${i + 1}. ${t}`).join('\n');
 
     for (const guild of client.guilds.cache.values()) {
@@ -141,7 +143,7 @@ async function sendTip(client) {
       const students = members.filter(m => m.roles.cache.has(studentRole.id) && !m.user.bot);
       for (const member of students.values()) {
         try {
-          await member.send(`\uD83D\uDCDA **Study Tip${numTips > 1 ? 's' : ''}:**\n${msg}`);
+          await member.send(`\uD83D\uDCDA **Study Tip:**\n${msg}`);
         } catch (err) {
           console.error('Failed to DM study tip to', member.user.tag, err);
         }
@@ -167,12 +169,9 @@ function buildEmbed() {
   const next = nextTriggerDate();
   const desc = [
     `**Status:** ${config.enabled ? 'Enabled' : 'Disabled'}`,
-    `**Time (UTC):** ${String(config.hour).padStart(2, '0')}:${String(config.minute).padStart(2, '0')}`,
-    `**Every:** ${config.days} day(s)`,
-    `**Tips per send:** ${config.count}`,
-    `**Next send:** ${next.toUTCString()}`,
+    `**Next send (UTC):** ${next.toUTCString()}`,
     '',
-    'Use the dropdowns below to adjust the hour, minute, frequency and tip count.'
+    'Tips are sent every Sunday at 12:00 UK time.'
   ].join('\n');
   return new EmbedBuilder()
     .setTitle('Study Tip Settings')
@@ -181,63 +180,13 @@ function buildEmbed() {
 }
 
 function buildComponents() {
-  const row1 = new ActionRowBuilder().addComponents(
+  const row = new ActionRowBuilder().addComponents(
     new ButtonBuilder()
       .setCustomId(config.enabled ? 'study-disable' : 'study-enable')
       .setLabel(config.enabled ? 'Disable' : 'Enable')
       .setStyle(config.enabled ? ButtonStyle.Danger : ButtonStyle.Success)
   );
-
-
-  const hourMenu = new StringSelectMenuBuilder()
-    .setCustomId('study-hour-select')
-    .setPlaceholder('Hour (UTC)')
-    .addOptions(
-      Array.from({ length: 24 }, (_, i) => ({
-        label: `${String(i).padStart(2, '0')} h`,
-        value: String(i),
-        default: config.hour === i,
-      }))
-    );
-
-  const minuteMenu = new StringSelectMenuBuilder()
-    .setCustomId('study-minute-select')
-    .setPlaceholder('Minute')
-    .addOptions(
-      Array.from({ length: 12 }, (_, i) => i * 5).map((m) => ({
-        label: `${String(m).padStart(2, '0')} min`,
-        value: String(m),
-        default: config.minute === m,
-      }))
-    );
-
-  const freqMenu = new StringSelectMenuBuilder()
-    .setCustomId('study-freq-select')
-    .setPlaceholder('Frequency (days)')
-    .addOptions(
-      Array.from({ length: 7 }, (_, i) => i + 1).map((d) => ({
-        label: `${d} day${d === 1 ? '' : 's'}`,
-        value: String(d),
-        default: config.days === d,
-      }))
-    );
-
-  const countMenu = new StringSelectMenuBuilder()
-    .setCustomId('study-count-select')
-    .setPlaceholder('Tips per send')
-    .addOptions(
-      Array.from({ length: 5 }, (_, i) => i + 1).map((c) => ({
-        label: `${c} tip${c === 1 ? '' : 's'}`,
-        value: String(c),
-        default: config.count === c,
-      }))
-    );
-
-  const row2 = new ActionRowBuilder().addComponents(hourMenu);
-  const row3 = new ActionRowBuilder().addComponents(minuteMenu);
-  const row4 = new ActionRowBuilder().addComponents(freqMenu);
-  const row5 = new ActionRowBuilder().addComponents(countMenu);
-  return [row1, row2, row3, row4, row5];
+  return [row];
 }
 
 async function postPanel(channel) {
@@ -288,41 +237,9 @@ async function handleStudyTipButton(interaction) {
   await refreshPanel(interaction.guild);
 }
 
-async function handleStudyTipSelect(interaction) {
-  if (!interaction.member.roles.cache.some(r => r.name === 'Staff')) {
-    return interaction.reply({ content: '⛔ Staff only.', ephemeral: true });
-  }
-  const val = interaction.values[0];
-  let msg;
-  switch (interaction.customId) {
-    case 'study-hour-select':
-      config.hour = parseInt(val, 10);
-      msg = `Hour set to ${String(config.hour).padStart(2, '0')} UTC.`;
-      break;
-    case 'study-minute-select':
-      config.minute = parseInt(val, 10);
-      msg = `Minute set to ${String(config.minute).padStart(2, '0')}.`;
-      break;
-    case 'study-freq-select':
-      config.days = parseInt(val, 10);
-      msg = `Frequency set to every ${config.days} day(s).`;
-      break;
-    case 'study-count-select':
-      config.count = parseInt(val, 10);
-      msg = `Each reminder will contain ${config.count} tip(s).`;
-      break;
-    default:
-      return;
-  }
-  saveConfig();
-  scheduleNext(interaction.client);
-  await interaction.reply({ content: msg, ephemeral: true });
-  await refreshPanel(interaction.guild);
-}
 
 module.exports = {
   setupStudyTips,
   ensureSettingsChannel,
   handleStudyTipButton,
-  handleStudyTipSelect,
 };

--- a/studyTipConfig.json
+++ b/studyTipConfig.json
@@ -1,9 +1,4 @@
 {
   "enabled": true,
-  "hour": 9,
-  "minute": 0,
-  "days": 1,
-  "count": 1,
-  "dayOfWeek": null,
   "settingsChannelId": "1399116716293755031"
 }


### PR DESCRIPTION
## Summary
- simplify study tip feature with a single enable/disable button
- schedule tips every Sunday at 12:00 UK time
- remove configuration controls and old settings
- update documentation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68869015904c83209fbafda9b2b9784e