### PR TITLE
Simplify study tip scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,5 @@ Heroku reads the `Procfile` and runs `npm start` continuously. Set the same envi
 
 ## Study tips
 
-A dedicated `#study-tip-settings` channel lets staff control how often tips are sent.
-The pinned panel provides dropdown menus for the hour, minute, frequency and tip count. Each menu's options include units (e.g. `09 h`, `30 min`) so it's clear what you're setting. New tips are generated with ChatGPT and are delivered to every student via DM.
-The pinned panel provides dropdown menus for the hour, minute, frequency and tip count. New tips are generated with ChatGPT and are delivered to every student via DM.
-The pinned panel provides dropdown menus for the hour, minute, frequency and tip count, plus a day-of-week selector. New tips are generated with ChatGPT and are delivered to every student via DM.
+A dedicated `#study-tip-settings` channel lets staff enable or disable weekly tips.
+When enabled, every student receives a new tip via DM each Sunday at **12:00 UK time**.

--- a/bot.js
+++ b/bot.js
@@ -844,12 +844,7 @@ client.on('interactionCreate', async (interaction) => {
         await handleEditQueueModal(interaction);
         return;
     }
-    if (interaction.isStringSelectMenu() && interaction.customId.startsWith('study-')) {
-        await studyTips.handleStudyTipSelect(interaction);
-        return;
-    }
-    
-    if (!interaction.isButton() && !interaction.isStringSelectMenu()) return;
+    if (!interaction.isButton()) return;
 
     // Let the generalQuestion collector handle these
     if (interaction.customId === 'yes_private_help' || interaction.customId === 'no_private_help') {
@@ -927,12 +922,6 @@ client.on('interactionCreate', async (interaction) => {
                 await studyTips.handleStudyTipButton(interaction);
                 break;
             
-            case 'study-hour-select':
-            case 'study-minute-select':
-            case 'study-freq-select':
-            case 'study-count-select':
-                await studyTips.handleStudyTipSelect(interaction);
-                break;
 
           /* ---------- Fallback ---------- */
           default:

--- a/studyTipConfig.json
+++ b/studyTipConfig.json
@@ -1,9 +1,4 @@
 {
   "enabled": true,
-  "hour": 9,
-  "minute": 0,
-  "days": 1,
-  "count": 1,
-  "dayOfWeek": null,
   "settingsChannelId": "1399116716293755031"
 }


### PR DESCRIPTION
## Summary
- simplify study tip feature with a single enable/disable button
- schedule tips every Sunday at 12:00 UK time
- remove configuration controls and old settings
- update documentation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68869015904c83209fbafda9b2b9784e